### PR TITLE
LAGLESS-64：振込依頼書PDFの日付を最も遅い支払日にする

### DIFF
--- a/kintone_js/generate_invoice_button.js
+++ b/kintone_js/generate_invoice_button.js
@@ -20,6 +20,9 @@ const id_logo = require("./images/id_logo.png");
 const holiday_jp = require("@holiday-jp/holiday_jp");
 const dateFns = require("date-fns");
 
+const dayjs = require("dayjs");
+dayjs.locale("ja");
+
 (function() {
     "use strict";
 
@@ -381,13 +384,10 @@ const dateFns = require("date-fns");
 
         // 振込依頼書に記載する日付。Y年M月D日
         // 支払明細の申込レコードの中で、最も遅い支払日を採用する
-        const detail_payment_dates =  parent_record.detail_records.map((record) => {
-            const ymd_array = (record[fieldPayDate_APPLY]["value"]).split("-").map((n) => Number(n));
-            return new Date(ymd_array[0], ymd_array[1]-1, ymd_array[2]);
-        });
-        const latest_date = new Date(Math.max(...detail_payment_dates));
+        const detail_payment_dates =  parent_record.detail_records.map((record) => dayjs(record[fieldPayDate_APPLY]["value"]));
+        const latest_date = dayjs(Math.max(...detail_payment_dates));
         const send_date = {
-            text: `${latest_date.getFullYear()}年${latest_date.getMonth() + 1}月${latest_date.getDate()}日`,
+            text: latest_date.format("YYYY年M月D日"),
             alignment: "right",
             fontSize: 10
         };

--- a/kintone_js/package-lock.json
+++ b/kintone_js/package-lock.json
@@ -1096,6 +1096,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.13.0.tgz",
       "integrity": "sha512-xm0c61mevGF7f0XpCGtDTGpzEFC/1fpLXHbmFpxZZQJuvByIK2ozm6cSYuU+nxFYOPh2EuCfzUwlTEFwKG+h5w=="
     },
+    "dayjs": {
+      "version": "1.8.28",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.28.tgz",
+      "integrity": "sha512-ccnYgKC0/hPSGXxj7Ju6AV/BP4HUkXC2u15mikXT5mX9YorEaoi1bEKOmAqdkJHN4EEkmAf97SpH66Try5Mbeg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/kintone_js/package.json
+++ b/kintone_js/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@holiday-jp/holiday_jp": "^2.2.3",
     "date-fns": "^2.13.0",
+    "dayjs": "^1.8.28",
     "encoding-japanese": "^1.0.30",
     "pdfmake": "^0.1.65"
   }


### PR DESCRIPTION
https://takadaid.backlog.com/view/LAGLESS-64
支払明細行に載っている支払日を使用するようにします。
期限を過ぎてるけど申込があった場合、本来の支払日を過ぎてから別途支払いをするイレギュラーなパターンが存在します。
そのイレギュラーに対応するため、複数の支払日の中から最も遅いものを選ぶようにしています。