### PR TITLE
Lagless 148：特定の工務店に関しては、ラグレス申込回数のカウント対象外とする（kintone_js）

### DIFF
--- a/kintone_js/count_application_button.js
+++ b/kintone_js/count_application_button.js
@@ -110,7 +110,7 @@
                 });
 
             // 協力会社ごとにカウント条件に当てはまる申込だけをカウント
-            const [count_result, ignored_records] = await countByKyoryokuId(target_applies, construction_shops, patterns);
+            const {count_result, ignored_records} = await countByKyoryokuId(target_applies, construction_shops, patterns);
 
             const update_records_num = await updateKyoryokuMaster(count_result)
                 .catch((err) => {
@@ -263,7 +263,10 @@
             };
         }
 
-        return [counts, ignored_records];
+        return {
+            count_result: counts,
+            ignored_records: ignored_records
+        };
     }
 
     function getDateFromYYYYMMDD(yyyy_mm_dd) {


### PR DESCRIPTION
https://github.com/invest-d/lagless-reminder/pull/17 と同様の趣旨の変更です。
上記PRはherokuから定期実行するpythonファイルの修正、本PRはkintone上に設置したボタンからいつでも手動でカウントできるjavascriptファイルの修正になります。