### PR TITLE
LAGLESS-152: 案内ページ・申込フォームのURLパラメータに協力会社IDを追加

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -137,11 +137,11 @@ const show = function(client, param) {
         $(".limit-precaution").text(`早払い年間利用回数制限${client.limit}。`);
     }
     $(`.cond-${mode}`).show();
-    $(".form_1").attr("href", `./apply.html?user=new&c=${param.c}&product=${mode}`);
-    $(".form_2").attr("href", `./apply.html?user=existing&c=${param.c}&product=${mode}`);
+    $(".form_1").attr("href", `./apply.html?user=new&c=${param.c}&a=${param.a}&product=${mode}`); // param.aはURLに表示するだけなのでundefinedでも問題ない
+    $(".form_2").attr("href", `./apply.html?user=existing&c=${param.c}&a=${param.a}&product=${mode}`);
     // 遅払い用
-    $(".form_3").attr("href", `./apply.html?user=new&c=${param.c}&product=${mode}&t=late`);
-    $(".form_4").attr("href", `./apply.html?user=existing&c=${param.c}&product=${mode}&t=late`);
+    $(".form_3").attr("href", `./apply.html?user=new&c=${param.c}&a=${param.a}&product=${mode}&t=late`);
+    $(".form_4").attr("href", `./apply.html?user=existing&c=${param.c}&a=${param.a}&product=${mode}&t=late`);
     if(client.link) {
         $(".link").attr("href", client.link).text(client.link);
         $(".link").parents("div").show();


### PR DESCRIPTION
https://takadaid.backlog.com/view/LAGLESS-152

パラメータは主にrollbarへの通知に載せることが目的です。
何らかのエラーが発生した場合に、rollbarでURLから協力会社IDを特定できれば、誰が申込をしようとしてくれたのかが分かるようになる。という流れが狙いです。

そもそもの第一歩である案内メールに載っているURLへのパラメータ追加は https://github.com/invest-d/lagless-reminder/pull/19 で行っています。