### PR TITLE
常に全フィールドを取得するようにしてバグの発生を未然に防ぐ。

### DIFF
--- a/kintone_js/app_apply/button_wfi_antisocial_check.js
+++ b/kintone_js/app_apply/button_wfi_antisocial_check.js
@@ -220,7 +220,6 @@ export const getCompanyRecord = (info) => {
 
     const body = {
         app: schema_28.id.appId,
-        fields: [recordNo_COMPANY],
         query: queries.join(" or ")
     };
     return CLIENT.record.getRecords(body);


### PR DESCRIPTION
レコード取得後に参照するfieldsを増やしたのに、取得するフィールドの方を増やしていなかったためにバグが発生した。